### PR TITLE
enh: make this module compatible with mongdb replica-set. fixes #2

### DIFF
--- a/etc/modules/mongodb.cfg
+++ b/etc/modules/mongodb.cfg
@@ -9,4 +9,6 @@ define module {
     database        shinken
     #username        username     ;optional
     #password        password     ;optional
+	
+    #replica_set                  ;Advanced option if you are running a cluster environnement
 }


### PR DESCRIPTION
Make this module compatible with mongdb replica-set:
- add import ReplicaSetConnection from pymongo
- add "replica_set" parameter in "get_instance" method
- add "self.replica_set" paramater in "**init**" method 
- making connection to mongodb replica-set if parameter provided in cfg
- finally edit and add "replica-set" parameter to "/etc/modules/mongodb.cfg"

Briefly, I reuse bulks of code from mod-retention-mongodb which already handles Replica-set connection.
